### PR TITLE
Change steam strategy require to be truly relative

### DIFF
--- a/lib/omniauth-steam.rb
+++ b/lib/omniauth-steam.rb
@@ -1,2 +1,2 @@
 require "omniauth-steam/version"
-require "omniauth/strategies/steam"
+require File.expand_path("../omniauth/strategies/steam", __FILE__)


### PR DESCRIPTION
This change makes it explicit that the require is loaded relatively. As it is, the `lib/omniauth/strategies/steam.rb` in the `omniauth-openid` gem seems to be taking precedence (the [changes you made](https://github.com/intridea/omniauth-openid/commit/c8d85def5ffc3953eb5f0407d880da9412ccc553) have not been mirrored in `omniauth-openid`'s repository), and is therefore breaking `omniauth-steam` when these two gems are implemented together. Details [here](https://github.com/intridea/omniauth-openid/issues/22).
