### PR TITLE
Change steam's class requires.

### DIFF
--- a/lib/omniauth-steam.rb
+++ b/lib/omniauth-steam.rb
@@ -1,2 +1,2 @@
 require "omniauth-steam/version"
-require File.expand_path("../omniauth/strategies/steam", __FILE__)
+require_relative "omniauth/strategies/steam"


### PR DESCRIPTION
```
require File.expand_path("../omniauth/strategies/steam", __FILE__)
```
This code is old solution. In now, we have `require_relative`.
Ruby versions: 1.9.*, latest.