### PR TITLE
use https when making steam webapi calls

### DIFF
--- a/lib/omniauth/strategies/steam.rb
+++ b/lib/omniauth/strategies/steam.rb
@@ -54,11 +54,11 @@ module OmniAuth
       end
 
       def player_profile_uri
-        URI.parse("http://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=#{options.api_key}&steamids=#{steam_id}")
+        URI.parse("https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=#{options.api_key}&steamids=#{steam_id}")
       end
 
       def friend_list_url
-        URI.parse("http://api.steampowered.com/ISteamUser/GetFriendList/v0001/?key=#{options.api_key}&steamid=#{steam_id}&relationship=friend")
+        URI.parse("https://api.steampowered.com/ISteamUser/GetFriendList/v0001/?key=#{options.api_key}&steamid=#{steam_id}&relationship=friend")
       end
     end
   end


### PR DESCRIPTION
use https when making steam webapi calls to avoid passing steam api-key in the clear
