### PR TITLE
Fix mismatch due to steam returning an https uri now

### DIFF
--- a/lib/omniauth/strategies/steam.rb
+++ b/lib/omniauth/strategies/steam.rb
@@ -52,7 +52,7 @@ module OmniAuth
       def steam_id
         @steam_id ||= begin
                         claimed_id = openid_response.display_identifier.split('/').last
-                        expected_uri = "http://steamcommunity.com/openid/id/#{claimed_id}"
+                        expected_uri = "https://steamcommunity.com/openid/id/#{claimed_id}"
                         if openid_response.endpoint.claimed_id != expected_uri
                           raise 'Steam Claimed ID mismatch!'
                         end


### PR DESCRIPTION
Steam started returning a https uri in the openid response, causing a mismatch with the expected uri. This PR just changes it to expect an https uri.