### PR TITLE
Send the newly required Origin header when POSTing to openid/login

### DIFF
--- a/lib/omniauth/strategies/steam.rb
+++ b/lib/omniauth/strategies/steam.rb
@@ -40,16 +40,22 @@ module OmniAuth
       end
 
       def callback_phase
-        return fail!(:invalid_credentials) if invalid_params?
+        return fail!(:invalid_credentials) unless valid_params? && valid_openid?
 
         super
       end
 
       private
 
-      def invalid_params?
-        request.params.keys.any? do |key|
-          !allowed_params.include?(key)
+      def valid_openid?
+        request.params['openid.ns'] == 'http://specs.openid.net/auth/2.0' &&
+          request.params['openid.identity'].start_with?('https://steamcommunity.com/openid/id/') &&
+          request.params['openid.claimed_id'].start_with?('https://steamcommunity.com/openid/id/')
+      end
+
+      def valid_params?
+        request.params.keys.all? do |key|
+          allowed_params.include?(key)
         end
       end
 

--- a/lib/omniauth/strategies/steam.rb
+++ b/lib/omniauth/strategies/steam.rb
@@ -39,7 +39,35 @@ module OmniAuth
         end
       end
 
+      def callback_phase
+        return fail!(:invalid_credentials) if invalid_params?
+
+        super
+      end
+
       private
+
+      def invalid_params?
+        request.params.keys.any? do |key|
+          !allowed_params.include?(key)
+        end
+      end
+
+      def allowed_params
+        [
+          '_method',
+          'openid.ns',
+          'openid.mode',
+          'openid.op_endpoint',
+          'openid.claimed_id',
+          'openid.identity',
+          'openid.return_to',
+          'openid.response_nonce',
+          'openid.assoc_handle',
+          'openid.signed',
+          'openid.sig'
+        ]
+      end
 
       def raw_info
         @raw_info ||= options.api_key ? MultiJson.decode(Net::HTTP.get(player_profile_uri)) : {}

--- a/lib/omniauth/strategies/steam.rb
+++ b/lib/omniauth/strategies/steam.rb
@@ -1,14 +1,33 @@
 require 'omniauth-openid'
 require 'multi_json'
+require 'openid/fetchers'
 
 module OmniAuth
   module Strategies
     class Steam < OmniAuth::Strategies::OpenID
+      class SteamFetcher < ::OpenID::StandardFetcher
+        def fetch(url, body=nil, headers=nil, redirect_limit=5)
+          headers ||= {}
+          if url.to_s.include?('steamcommunity.com/openid/login')
+            headers['Origin'] = 'https://steamcommunity.com'
+          end
+          super(url, body, headers, redirect_limit)
+        end
+      end
+
       args :api_key
 
       option :api_key, nil
       option :name, "steam"
       option :identifier, "http://steamcommunity.com/openid"
+
+      def setup_phase
+        existing_fetcher = ::OpenID.fetcher
+        fetcher = SteamFetcher.new
+        fetcher.ca_file = existing_fetcher.ca_file if existing_fetcher.respond_to?(:ca_file)
+        ::OpenID.fetcher = fetcher
+        super
+      end
 
       uid { steam_id }
 


### PR DESCRIPTION
Fix two vulnerabilities based on the work of the passport-steam node.js library. 

1. Check for the correct `ns`,  `identity` and `claimed_id`. See https://github.com/liamcurry/passport-steam/pull/120#issuecomment-1596185704 for how this was abused.
2. Check there aren't any extra query parameters in the callback URL. This was used to inject extra parameters containing unicode null bytes, allowing logging in with a steam id of the attacker's choosing. Based on https://github.com/liamcurry/passport-steam/pull/127